### PR TITLE
fix: use secrets.* for SonarQube env vars

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,10 +129,10 @@ jobs:
           sonar.verbose=false
           EOF
         env:
-          SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+          SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}
 
       - name: Run SonarQube analysis
         uses: SonarSource/sonarqube-scan-action@fd88b7d7ccbaefd23d8f36f73b59db7a3d246602 # v6.0.0
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+          SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}


### PR DESCRIPTION
## SonarQube CI Fix

### What was wrong

The workflow was reading `SONAR_HOST_URL` and `SONAR_PROJECT_KEY` using `vars.*` (GitHub Variables), but the automated provisioner (sonarqube-provisioner.yml) writes them as `secrets.*` (GitHub Secrets). These are completely separate stores — `vars.*` always returned an empty string, causing the SonarQube scanner to fail with _"URI with undefined scheme"_.

### What was changed

```diff
- SONAR_PROJECT_KEY: ${{ vars.SONAR_PROJECT_KEY }}
+ SONAR_PROJECT_KEY: ${{ secrets.SONAR_PROJECT_KEY }}

- SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+ SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
```

### Environment setup

The `sonarqube` GitHub environment has been pre-populated with all three required secrets (`SONAR_HOST_URL`, `SONAR_PROJECT_KEY`, `SONAR_TOKEN`) so SonarQube analysis will work immediately after this PR is merged — no manual setup needed.
